### PR TITLE
🐛 Fix regex for replacing invalid characters in Lokse translations

### DIFF
--- a/template/tooling/lokse/scripts/transformTranslations.js
+++ b/template/tooling/lokse/scripts/transformTranslations.js
@@ -15,7 +15,7 @@ function normalizeValue(value) {
      * - \u2028: Line separator (https://www.compart.com/en/unicode/U+2028)
      * - \u2029: Paragraph separator (https://www.compart.com/en/unicode/U+2029)
      */
-    const invalidCharsRegex = /[\u2028|\u2029]/g;
+    const invalidCharsRegex = /[\u2028\u2029]/g;
 
     if (value.match(invalidCharsRegex)) {
         value = value.replaceAll(invalidCharsRegex, '\n');


### PR DESCRIPTION
The original regex matched not only `\u2028` and `\u2029` characters, but also the vertical line character `|` that is perfectly safe to have in a JSON. 

Original regex: https://regex101.com/r/OuLt3U/1
New regex: https://regex101.com/r/zbHBjs/1